### PR TITLE
change-input-focus-behavior

### DIFF
--- a/src/components/game/Keyboard.tsx
+++ b/src/components/game/Keyboard.tsx
@@ -209,7 +209,11 @@ const Keyboard = () => {
 						value={currentWord}
 						size='small'
 						disabled={isAnimating}
-						inputRef={(input) => input && input.focus()}
+						inputRef={(input) => {
+							if (window.innerWidth > 768) {
+								input && input.focus()
+							}
+						}}
 						inputProps={{
 							margin: 0,
 							maxLength: 4,


### PR DESCRIPTION
Changed input focus behavior, preventing IME from popping up when using on-screen keyboard on mobile device.