### PR TITLE
Fix issue where 12 bingo lines are incorrectly recognized as 11 lines

### DIFF
--- a/src/components/charts/StatBarChart.tsx
+++ b/src/components/charts/StatBarChart.tsx
@@ -6,6 +6,17 @@ const StatBarChart = () => {
 		return { name, value }
 	})
 
+	const getFillColor = (i: number): string => {
+		if (mojibiState['gameStatus'] != 'IN_PROGRESS') {
+			if (i < 11) {
+				if (i === mojibiState['completedLines']) return '#538d4e'
+			} else if (i === 11) {
+				if (i === mojibiState['completedLines'] - 1) return '#538d4e'
+			}
+		}
+		return '#3a3a3c'
+	}
+
 	return (
 		<ResponsiveContainer width='100%' height={290}>
 			<BarChart data={data} layout='vertical'>
@@ -22,11 +33,7 @@ const StatBarChart = () => {
 					{data.map((entry, index) => (
 						<Cell
 							key={`cell-${index}`}
-							fill={
-								index == mojibiState['completedLines'] && mojibiState['gameStatus'] != 'IN_PROGRESS'
-									? '#538d4e'
-									: '#3a3a3c'
-							}
+							fill={getFillColor(index)}
 						/>
 					))}
 				</Bar>

--- a/src/components/game/Keyboard.tsx
+++ b/src/components/game/Keyboard.tsx
@@ -154,8 +154,7 @@ const Keyboard = () => {
 				mojibiStats['winPercentage'] = (mojibiStats['gamesWon'] / mojibiStats['gamesPlayed']) * 100
 				mojibiStats['lines'][completedLines] += 1
 
-				const linesArray = Object.values(mojibiStats['lines'])
-				const [averageLines, rank] = getAverageAndRank(linesArray)
+				const [averageLines, rank] = getAverageAndRank(mojibiStats['lines'])
 				mojibiStats['averageLines'] = averageLines
 				mojibiStats['rank'] = rank
 


### PR DESCRIPTION
Fix an issue where 12 completed bingo lines are wrongly recognized as 11 lines.
Fix an issue where bar chart doesnt turn green when you complete 12 lines.